### PR TITLE
Update the handlers, app env and dispatch to support the new Cowboy 0.8.5 way of doing things

### DIFF
--- a/src/folsom_cowboy.app.src
+++ b/src/folsom_cowboy.app.src
@@ -19,17 +19,17 @@
          {transport_options, []},
          {dispatch,
           [{'_', [
-                  {[<<"_health">>], folsom_cowboy_health_handler, []},
-                  {[<<"_memory">>], folsom_cowboy_memory_handler, []},
-                  {[<<"_metrics">>], folsom_cowboy_metrics_list_handler, []},
-                  {[<<"_metrics">>, '_'], folsom_cowboy_metrics_handler, []},
-                  {[<<"_ping">>], folsom_cowboy_ping_handler, []},
-                 {[<<"_port">>], folsom_cowboy_port_handler, []},
-                  {[<<"_process">>], folsom_cowboy_process_handler, []},
-                  {[<<"_statistics">>], folsom_cowboy_statistics_handler, []},
-                  {[<<"_system">>], folsom_cowboy_system_handler, []},
-                  {[<<"_ets">>], folsom_cowboy_ets_handler, []},
-                  {[<<"_dets">>], folsom_cowboy_dets_handler, []}
+                  {"/_health", folsom_cowboy_health_handler, []},
+                  {"/_memory", folsom_cowboy_memory_handler, []},
+                  {"/_metrics", folsom_cowboy_metrics_list_handler, []},
+                  {"/_metrics/[:metric_id]", folsom_cowboy_metrics_handler, []},
+                  {"/_ping", folsom_cowboy_ping_handler, []},
+                  {"/_port", folsom_cowboy_port_handler, []},
+                  {"/_process", folsom_cowboy_process_handler, []},
+                  {"/_statistics", folsom_cowboy_statistics_handler, []},
+                  {"/_system", folsom_cowboy_system_handler, []},
+                  {"/_ets", folsom_cowboy_ets_handler, []},
+                  {"/_dets", folsom_cowboy_dets_handler, []}
                  ]}]}
         ]}
  ]}.

--- a/src/folsom_cowboy_app.erl
+++ b/src/folsom_cowboy_app.erl
@@ -33,8 +33,11 @@
 -define(APP, folsom_cowboy).
 
 start(_Type, _Args) ->
-    cowboy:start_http(folsom_cowboy_listener, env(num_acceptors),
-                      [{port, env(port)}], [{dispatch, env(dispatch)}]),
+    Dispatch = cowboy_router:compile(env(dispatch)),
+
+    {ok, _Pid} = cowboy:start_http(folsom_cowboy_listener, env(num_acceptors),
+                      [{port, env(port)}], 
+		      [{env, [{dispatch, Dispatch}] } ]),
     folsom_cowboy_sup:start_link().
 
 stop(_State) ->

--- a/src/folsom_cowboy_dets_handler.erl
+++ b/src/folsom_cowboy_dets_handler.erl
@@ -25,7 +25,7 @@
 
 -module(folsom_cowboy_dets_handler).
 -behaviour(cowboy_http_handler).
--export([init/3, handle/2, terminate/2]).
+-export([init/3, handle/2, terminate/3]).
 
 init({_Any, http}, Req, []) ->
     {ok, Req, undefined}.
@@ -34,5 +34,5 @@ handle(Req, State) ->
     {ok, Req2} = cowboy_req:reply(200, [], mochijson2:encode(folsom_vm_metrics:get_dets_info()), Req),
     {ok, Req2, State}.
 
-terminate(_Req, _State) ->
+terminate(_Reason, _Req, _State) ->
     ok.

--- a/src/folsom_cowboy_ets_handler.erl
+++ b/src/folsom_cowboy_ets_handler.erl
@@ -25,7 +25,7 @@
 
 -module(folsom_cowboy_ets_handler).
 -behaviour(cowboy_http_handler).
--export([init/3, handle/2, terminate/2]).
+-export([init/3, handle/2, terminate/3]).
 
 init({_Any, http}, Req, []) ->
     {ok, Req, undefined}.
@@ -34,5 +34,5 @@ handle(Req, State) ->
     {ok, Req2} = cowboy_req:reply(200, [], mochijson2:encode(folsom_vm_metrics:get_ets_info()), Req),
     {ok, Req2, State}.
 
-terminate(_Req, _State) ->
+terminate(_Reason, _Req, _State) ->
     ok.

--- a/src/folsom_cowboy_health_handler.erl
+++ b/src/folsom_cowboy_health_handler.erl
@@ -25,7 +25,7 @@
 
 -module(folsom_cowboy_health_handler).
 -behaviour(cowboy_http_handler).
--export([init/3, handle/2, terminate/2]).
+-export([init/3, handle/2, terminate/3]).
 
 init({_Any, http}, Req, []) ->
     {ok, Req, undefined}.
@@ -38,5 +38,5 @@ handle(Req, State) ->
     {ok, Req2} = cowboy_req:reply(200, [], mochijson2:encode([{<<"health">>, Result}]), Req),
     {ok, Req2, State}.
 
-terminate(_Req, _State) ->
+terminate(_Reason, _Req, _State) ->
     ok.

--- a/src/folsom_cowboy_memory_handler.erl
+++ b/src/folsom_cowboy_memory_handler.erl
@@ -26,7 +26,7 @@
 
 -module(folsom_cowboy_memory_handler).
 -behaviour(cowboy_http_handler).
--export([init/3, handle/2, terminate/2]).
+-export([init/3, handle/2, terminate/3]).
 
 init({_Any, http}, Req, []) ->
     {ok, Req, undefined}.
@@ -35,5 +35,5 @@ handle(Req, State) ->
     {ok, Req2} = cowboy_req:reply(200, [], mochijson2:encode(folsom_vm_metrics:get_memory()), Req),
     {ok, Req2, State}.
 
-terminate(_Req, _State) ->
+terminate(_Reason, _Req, _State) ->
     ok.

--- a/src/folsom_cowboy_metrics_list_handler.erl
+++ b/src/folsom_cowboy_metrics_list_handler.erl
@@ -26,7 +26,7 @@
 
 -module(folsom_cowboy_metrics_list_handler).
 -behaviour(cowboy_http_handler).
--export([init/3, handle/2, terminate/2]).
+-export([init/3, handle/2, terminate/3]).
 
 init({_Any, http}, Req, []) ->
     {ok, Req, undefined}.
@@ -36,10 +36,10 @@ handle(Req, State) ->
     {ok, Req2} = get_request(Info),
     {ok, Req2, State}.
 
-terminate(_Req, _State) ->
+terminate(_Reason, _Req, _State) ->
     ok.
 
 get_request({<<"true">>, Req}) ->
     cowboy_req:reply(200, [], mochijson2:encode(folsom_metrics:get_metrics_info()), Req);
 get_request({_, Req}) ->
-    cowboy_req:reply(200, [], mochijson2:encode(folsom_metrics:get_metrics()), Req).
+    cowboy_req:reply(200, [], mochijson2:encode(folsom_metrics:get_metrics()), Req). 

--- a/src/folsom_cowboy_ping_handler.erl
+++ b/src/folsom_cowboy_ping_handler.erl
@@ -25,7 +25,7 @@
 
 -module(folsom_cowboy_ping_handler).
 -behaviour(cowboy_http_handler).
--export([init/3, handle/2, terminate/2]).
+-export([init/3, handle/2, terminate/3]).
 
 init({_Any, http}, Req, []) ->
     {ok, Req, undefined}.
@@ -34,5 +34,5 @@ handle(Req, State) ->
     {ok, Req2} = cowboy_req:reply(200, [], mochijson2:encode([{<<"pong">>, ok}]), Req),
     {ok, Req2, State}.
 
-terminate(_Req, _State) ->
+terminate(_Reason, _Req, _State) ->
     ok.

--- a/src/folsom_cowboy_port_handler.erl
+++ b/src/folsom_cowboy_port_handler.erl
@@ -25,7 +25,7 @@
 
 -module(folsom_cowboy_port_handler).
 -behaviour(cowboy_http_handler).
--export([init/3, handle/2, terminate/2]).
+-export([init/3, handle/2, terminate/3]).
 
 init({_Any, http}, Req, []) ->
     {ok, Req, undefined}.
@@ -34,5 +34,5 @@ handle(Req, State) ->
     {ok, Req2} = cowboy_req:reply(200, [], mochijson2:encode(folsom_vm_metrics:get_port_info()), Req),
     {ok, Req2, State}.
 
-terminate(_Req, _State) ->
+terminate(_Reason, _Req, _State) ->
     ok.

--- a/src/folsom_cowboy_process_handler.erl
+++ b/src/folsom_cowboy_process_handler.erl
@@ -25,7 +25,7 @@
 
 -module(folsom_cowboy_process_handler).
 -behaviour(cowboy_http_handler).
--export([init/3, handle/2, terminate/2]).
+-export([init/3, handle/2, terminate/3]).
 
 init({_Any, http}, Req, []) ->
     {ok, Req, undefined}.
@@ -34,5 +34,5 @@ handle(Req, State) ->
     {ok, Req2} = cowboy_req:reply(200, [], mochijson2:encode(folsom_vm_metrics:get_process_info()), Req),
     {ok, Req2, State}.
 
-terminate(_Req, _State) ->
+terminate(_Reason, _Req, _State) ->
     ok.

--- a/src/folsom_cowboy_statistics_handler.erl
+++ b/src/folsom_cowboy_statistics_handler.erl
@@ -25,7 +25,7 @@
 
 -module(folsom_cowboy_statistics_handler).
 -behaviour(cowboy_http_handler).
--export([init/3, handle/2, terminate/2]).
+-export([init/3, handle/2, terminate/3]).
 
 init({_Any, http}, Req, []) ->
     {ok, Req, undefined}.
@@ -34,5 +34,5 @@ handle(Req, State) ->
     {ok, Req2} = cowboy_req:reply(200, [], mochijson2:encode(folsom_vm_metrics:get_statistics()), Req),
     {ok, Req2, State}.
 
-terminate(_Req, _State) ->
+terminate(_Reason, _Req, _State) ->
     ok.

--- a/src/folsom_cowboy_system_handler.erl
+++ b/src/folsom_cowboy_system_handler.erl
@@ -25,7 +25,7 @@
 
 -module(folsom_cowboy_system_handler).
 -behaviour(cowboy_http_handler).
--export([init/3, handle/2, terminate/2]).
+-export([init/3, handle/2, terminate/3]).
 
 init({_Any, http}, Req, []) ->
     {ok, Req, undefined}.
@@ -34,5 +34,5 @@ handle(Req, State) ->
     {ok, Req2} = cowboy_req:reply(200, [], mochijson2:encode(folsom_vm_metrics:get_system_info()), Req),
     {ok, Req2, State}.
 
-terminate(_Req, _State) ->
+terminate(_Reason, _Req, _State) ->
     ok.


### PR DESCRIPTION
Hopefully the Cowboy api is now going to be stable until 1.0.

Changes:
- switching the dispatch config to using "/path" instead of [<<"path">>]
- moving multi-part paths to cowboy path bindings
- updating the application startup to use the new cowboy_router compiler
