### PR TITLE
Properly string encode floats

### DIFF
--- a/src/mochijson2.erl
+++ b/src/mochijson2.erl
@@ -187,6 +187,8 @@ json_encode_string(B, State) when is_binary(B) ->
     end;
 json_encode_string(I, _State) when is_integer(I) ->
     [?Q, integer_to_list(I), ?Q];
+json_encode_string(F, _State) when is_float(F) ->
+    [?Q, erlang:hd(io_lib:format("~p", [F])), ?Q];
 json_encode_string(L, State) when is_list(L) ->
     case json_string_is_safe(L) of
         true ->


### PR DESCRIPTION
When encoding values in mochijson2:json_encode_string/2 float values do not have a separate clause and crash the function. We're observing this behavior in our production. 

For example this piece of data crashes the function as key is float:

``` erlang
{histogram, [{0.019488, 24}]}
```

```
** Stacktrace: [{mochijson2,json_encode_string,[0.019488,{encoder,null,false}],[{file,"src/mochijson2.erl"},{line,173}]},{mochijson2,'-json_encode_proplist/2-fun-0-',3,[{file,"src/mochijson2.erl"},{line,166}]},{lists,foldl,3,[{file,"lists.erl"},{line,1197}]},{mochijson2,json_encode_proplist,2,[{file,"src/mochijson2.erl"},{line,170}]},{mochijson2,'-json_encode_proplist/2-fun-0-',3,[{file,"src/mochijson2.erl"},{line,167}]},{lists,foldl,3,[{file,"lists.erl"},{line,1197}]},{mochijson2,json_encode_proplist,2,[{file,"src/mochijson2.erl"},{line,170}]},{mochijson2,'-json_encode_proplist/2-fun-0-',3,[{file,"src/mochijson2.erl"},{line,167}]}]
```

I'm using io_lib:format in the patch because float_to_list/2 was introduced only in R16B.
