### PR TITLE
Strip tags from get_metrics_info()

### DIFF
--- a/src/folsom_cowboy_metrics_handler.erl
+++ b/src/folsom_cowboy_metrics_handler.erl
@@ -50,7 +50,7 @@ terminate(_Reason, _Req, _State) ->
 
 get_metric_data(Id) ->
     case folsom_metrics:get_metric_info(Id) of
-        [{_, [{type, histogram}]}] ->
+        [{_, [{type, histogram} | _]}] ->
             [{value, folsom_metrics:get_histogram_statistics(Id)}];
         _ ->
             [{value, folsom_metrics:get_metric_value(Id)}]

--- a/src/folsom_cowboy_metrics_list_handler.erl
+++ b/src/folsom_cowboy_metrics_list_handler.erl
@@ -40,6 +40,9 @@ terminate(_Reason, _Req, _State) ->
     ok.
 
 get_request({<<"true">>, Req}) ->
-    cowboy_req:reply(200, [], mochijson2:encode(folsom_metrics:get_metrics_info()), Req);
+    Metrics = [{M, proplists:delete(tags, List)} ||
+               {M, List} <- folsom_metrics:get_metrics_info()],
+
+    cowboy_req:reply(200, [], mochijson2:encode(Metrics), Req);
 get_request({_, Req}) ->
     cowboy_req:reply(200, [], mochijson2:encode(folsom_metrics:get_metrics()), Req). 


### PR DESCRIPTION
After tags were introduced in https://github.com/boundary/folsom/commit/9745617d5d481b58a99459449a41647ddb30ecf0
the output format of folsom_metrics:get_metrics_info() has changed - a new item {tags, set()} is returned along with {type, TYPE}:

``` erlang
folsom_metrics:get_metric_info(<<"auth_attempt">>).                                                             [{<<"auth_attempt">>,
  [{type,spiral},
   {tags,{set,0,16,16,8,80,48,
              {[],[],[],[],[],[],[],[],[],[],[],[],[],[],...},
              {{[],[],[],[],[],[],[],[],[],[],[],[],...}}}}]}]
```

In folsom_cowboy_metrics_list_handler module however the output of folsom_metrics:get_metrics is being directly passed to mochijson2:encode, which crashes the function as it doesn't know how to encode  set(). The quick fix is to strip tags element before passing it to encode():

```
Ranch listener folsom_cowboy_listener had connection process started with cowboy_protocol:start_link/4 at <0.15034.37> exit with reason: [{reason,{json_encode,{bad_term,{set,0,16,16,8,80,48,{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},{{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]}}}}}},{mfa,{folsom_cowboy_metrics_list_handler,handle,2}},{stacktrace,[{mochijson2,json_encode,2,[{file,"src/mochijson2.erl"},{line,149}]},{mochijson2,'-json_encode_proplist/2-fun-0-',3,[{file,"src/mochijson2.erl"},{line,167}]},{lists,foldl,3,[{file,"lists.erl"},{line,1248}]},{mochijson2,json_encode_proplist,2,[{file,"src/mochijson2.erl"},{line,170}]},{mochijson2,'-json_encode_proplist/2-fun-0-',3,[{file,"src/mochijson2.erl"},{line,167}]},{lists,foldl,3,[{file,"lists.erl"},{line,1248}]},{mochijson2,json_encode_proplist,2,[{file,"src/mochijson2.erl"},{line,170}]},{folsom_cowboy_metrics_list_handler,get_request,1,[{file,"src/folsom_cowboy_metrics_list_handler.erl"},{line,43}]}]},{req,[{socket,#Port<0.835530>},{transport,ranch_tcp},{connection,keepalive},{pid,<0.15034.37>},{method,<<"GET">>},{version,'HTTP/1.1'},{peer,{{127,0,0,1},36140}},{host,<<"localhost">>},{host_info,undefined},{port,5565},{path,<<"/_metrics">>},{path_info,undefined},{qs,<<"info=true">>},{qs_vals,undefined},{bindings,[]},{headers,[{<<"accept">>,<<"*/*; q=0.5, application/xml">>},{<<"accept-encoding">>,<<"gzip, deflate">>},{<<"host">>,<<"localhost:5565">>}]},{p_headers,[]},{cookies,undefined},{meta,[]},{body_state,waiting},{buffer,<<>>},{multipart,undefined},{resp_compress,false},{resp_state,waiting},{resp_headers,[]},{resp_body,<<>>},{onresponse,undefined}]},{state,undefined}]
```
