### PR TITLE
Allow specifying listen IP address in configuration

### DIFF
--- a/src/folsom_cowboy.app.src
+++ b/src/folsom_cowboy.app.src
@@ -17,6 +17,7 @@
   {mod, {folsom_cowboy_app, []}},
   {env, [{health, {erlang, node, []}},
          {port, 5565},
+         {ip, {0,0,0,0}},
          {num_acceptors, 100},
          {transport, cowboy_tcp_transport},
          {transport_options, []},

--- a/src/folsom_cowboy_app.erl
+++ b/src/folsom_cowboy_app.erl
@@ -36,7 +36,7 @@ start(_Type, _Args) ->
     Dispatch = cowboy_router:compile(env(dispatch)),
 
     {ok, _Pid} = cowboy:start_http(folsom_cowboy_listener, env(num_acceptors),
-                      [{port, env(port)}], 
+                      [{port, env(port)}, {ip, env(ip)}],
 		      [{env, [{dispatch, Dispatch}] } ]),
     folsom_cowboy_sup:start_link().
 


### PR DESCRIPTION
Currently there is no way to specify an IP address to listen to, 0.0.0.0 which is default is not always suitable.
This simple patch fixes the issue.
