### PR TITLE
Use cowboy, branch 1.0.x instead of HEAD

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {deps, [
       {folsom, ".*", {git, "git://github.com/boundary/folsom", master}},
-      {cowboy, ".*", {git, "git://github.com/extend/cowboy", "HEAD"}},
+      {cowboy, ".*", {git, "git://github.com/ninenines/cowboy", "1.0.x"}},
       {ibrowse, ".*", {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v2.2.0"}}}
   ]}.
 {erl_opts, [debug_info]}.


### PR DESCRIPTION
Use cowboy, branch 1.0.x instead of HEAD since cowboy moved to incompatible branch 2.x.
