### PR TITLE
Add support to building as a dependency from erlang.mk

### DIFF
--- a/src/folsom_cowboy.app.src
+++ b/src/folsom_cowboy.app.src
@@ -3,6 +3,7 @@
  [
   {description, ""},
   {vsn, git},
+  {modules, []},
   {registered, [folsom_cowboy_listener,
                 folsom_cowboy_sup]},
   {applications, [


### PR DESCRIPTION
https://github.com/ninenines/erlang.mk wants to see an empty list of modules, which it fills in. 