### PR TITLE
Include xmerl in applications

### DIFF
--- a/src/folsom_cowboy.app.src
+++ b/src/folsom_cowboy.app.src
@@ -10,6 +10,7 @@
                   kernel,
                   stdlib,
                   crypto,
+                  xmerl,
                   ranch,
                   cowlib,
                   cowboy,


### PR DESCRIPTION
When creating a release xmerl is not automatically included even
though mochijson depends on it.